### PR TITLE
Implement a redirect endpoint

### DIFF
--- a/nginx/conf.d/include/locations.conf
+++ b/nginx/conf.d/include/locations.conf
@@ -11,6 +11,11 @@ location /webdav_health {
     access_log off;
 }
 
+location /redirect {
+    access_by_lua_file /etc/nginx/lua/webdav_access.lua;
+    content_by_lua_file /etc/nginx/lua/redirect_content.lua;
+}
+
 location /webdav {
     rewrite ^/webdav$ /webdav/;
     rewrite ^/webdav/(.*) /$upstream_location/$1 last;

--- a/nginx/docker-entrypoint.sh
+++ b/nginx/docker-entrypoint.sh
@@ -45,6 +45,7 @@ server {
     lua_code_cache off;
 }
 EOF
+  echo "Debug mode enabled"
 else
   cat <<EOF >> /etc/nginx/conf.d/site.conf
 error_log stderr warn;

--- a/nginx/docker-entrypoint.sh
+++ b/nginx/docker-entrypoint.sh
@@ -43,10 +43,6 @@ error_log stderr notice;
 
 server {
     lua_code_cache off;
-
-    location /webdav {
-        rewrite_log on;
-    }
 }
 EOF
 else

--- a/nginx/lua/init_worker.lua
+++ b/nginx/lua/init_worker.lua
@@ -26,7 +26,7 @@ local token_userpass = config.data.openidc_client_id .. ":" .. config.data.openi
 local function peer_exchange_gossip(peer, message, token)
     local httpc = resty_http.new()
     -- TODO: handle connection refused
-    local res, err = httpc:request_uri(peer .. "/gossip", {
+    local res, err = httpc:request_uri(peer .. "gossip", {
         method = "POST",
         body = message,
         headers = {
@@ -34,6 +34,7 @@ local function peer_exchange_gossip(peer, message, token)
             ["Content-Length"] = #message,
             ["Authorization"] = "Bearer " .. token,
             ["Accept"] = "application/json",
+            ["User-Agent"] = "nginx-webdav/" .. config.data.server_version,
         },
     })
     if not res then
@@ -79,6 +80,7 @@ local function worker_gossip(premature)
                 ["Content-Type"] = "application/x-www-form-urlencoded",
                 ["Accept"] = "application/json",
                 ["Authorization"] = "Basic " .. ngx.encode_base64(token_userpass),
+                ["User-Agent"] = "nginx-webdav/" .. config.data.server_version,
             },
         })
 

--- a/nginx/lua/redirect_content.lua
+++ b/nginx/lua/redirect_content.lua
@@ -1,0 +1,96 @@
+local ngx = require("ngx")
+local resty_http = require("resty.http")
+local fileutil = require("fileutil")
+local config = require("config")
+local gossip = require("gossip")
+
+
+-- TODO: always "redirect"?
+local path = ngx.var.request_uri:sub(#"/redirect" + 1)
+local webdav_uri = config.data.uriprefix .. path
+local stat = fileutil.get_metadata(config.data.local_path .. path, false)
+if stat.exists then
+    ngx.status = ngx.HTTP_TEMPORARY_REDIRECT
+    -- TODO: do we want to use the full url (config.data.server_address)
+    ngx.header["Location"] = webdav_uri
+    ngx.exit(ngx.OK)
+end
+
+---@type function
+---@param peer string Peer hostname
+---@param uri string File url to check
+---@param token string Bearer token for authentication
+---@return {peer: string, location: string?} res Response from peer
+local function peer_query_file(peer, uri, token)
+    local httpc = resty_http.new()
+    -- peer has trailing slash, uri has leading slash
+    local location = peer .. uri:sub(2)
+    ngx.log(ngx.NOTICE, "Querying location: ", location)
+    local res, err = httpc:request_uri(location, {
+        method = "HEAD",
+        headers = {
+            ["Authorization"] = "Bearer " .. token,
+            ["User-Agent"] = "nginx-webdav/" .. config.data.server_version,
+        },
+    })
+    if not res then
+        ngx.log(ngx.ERR, "Failed to send file query to " .. peer .. ": " .. err)
+        -- TODO: update peer status for gossip (unreachable)
+        return {peer = peer, location = nil}
+    end
+    if res.status == ngx.HTTP_OK then
+        ngx.log(ngx.NOTICE, "Found file on peer: ", peer)
+        return {peer = peer, location = location}
+    end
+    ngx.log(ngx.NOTICE, "Did not find file on peer: ", peer, " status: ", res.status)
+    return {peer = peer, location = nil}
+end
+
+-- Ask our peers if they have the file
+local tic = ngx.now()
+-- TODO: we could use the token that the client gives us, is that better?
+local token = ngx.shared.gossip_data:get("bearer_token")
+if not token then
+    ngx.log(ngx.ERR, "No bearer token found in shared dict")
+    ngx.status = ngx.HTTP_INTERNAL_SERVER_ERROR
+    ngx.exit(ngx.OK)
+end
+local peers, _ = gossip.peers()
+---@type table<string, ngx.thread>
+local threads = {}
+for peer, _ in pairs(peers) do
+    local co, err = ngx.thread.spawn(peer_query_file, peer, webdav_uri, token)
+    if not co then
+        ngx.log(ngx.ERR, "Failed to spawn thread: ", err)
+    else
+        threads[peer] = co
+    end
+end
+
+-- Wait for first thread to finish
+while next(threads) ~= nil do
+    local lthreads = {}
+    for _, thread in pairs(threads) do
+        table.insert(lthreads, thread)
+    end
+    local ok, res = ngx.thread.wait(unpack(lthreads))
+    if not ok then
+        ngx.log(ngx.ERR, "Thread error: ", res)
+        ngx.status = ngx.HTTP_INTERNAL_SERVER_ERROR
+        ngx.exit(ngx.OK)
+    else
+        threads[res.peer] = nil
+        if res.location then
+            ngx.status = ngx.HTTP_TEMPORARY_REDIRECT
+            ngx.header["Location"] = res.location
+            ngx.exit(ngx.OK)
+        end
+    end
+end
+
+-- No peers have the file, return 404
+ngx.status = ngx.HTTP_NOT_FOUND
+
+local toc = ngx.now()
+ngx.log(ngx.NOTICE, "Redirect took ", toc - tic, " seconds")
+ngx.exit(ngx.OK)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -237,8 +237,22 @@ def build_container():
     yield
 
 
+@dataclass
+class ServerInstance:
+    """A server instance for testing"""
+
+    port: int
+    "Port on which the server is running"
+    container_id: str
+    "Podman container ID"
+    podurl: str
+    "URL with hostname resolvable from the podman network"
+    hosturl: str
+    "URL with hostname (or IP) resolvable from the host (pytest) network"
+
+
 @pytest.fixture(scope="session")
-def setup_server(build_container: None, oidc_mock_idp: MockIdP) -> Iterator[dict[str, str]]:
+def setup_server(build_container: None, oidc_mock_idp: MockIdP):
     """A running nginx-webdav server for testing"""
     # Find an available port.
     open_port = 8280
@@ -321,7 +335,12 @@ def setup_server(build_container: None, oidc_mock_idp: MockIdP) -> Iterator[dict
             subprocess.check_call(["podman", "logs", container_id])
             raise RuntimeError("Container did not start")
 
-        yield {"port": open_port, "container_id": container_id}
+        yield ServerInstance(
+            port=open_port,
+            container_id=container_id,
+            podurl="http://nginx-unit-test-container:8080/webdav",
+            hosturl=f"http://localhost:{open_port}/webdav",
+        )
     finally:
         # Stop podman container and clean up
         subprocess.check_call(
@@ -383,7 +402,15 @@ def setup_cluster(build_container: None, oidc_mock_idp: MockIdP):
         container_id = subprocess.check_output(podman_cmd).decode().strip()
         container_ids.append(container_id)
 
-    yield [f"http://localhost:{8580 + i}/" for i in range(nservers)]
+    yield [
+        ServerInstance(
+            port=8580 + i,
+            container_id=container_id,
+            podurl=f"http://nginx-webdav-test{i}:{8580 + i}/",
+            hosturl=f"http://localhost:{8580 + i}/",
+        )
+        for i, container_id in enumerate(container_ids)
+    ]
 
     # Clean up
     for i, container_id in enumerate(container_ids):
@@ -403,7 +430,7 @@ def setup_cluster(build_container: None, oidc_mock_idp: MockIdP):
 
 
 @pytest.fixture()
-def nginx_server(setup_server) -> Iterator[str]:
+def nginx_server(setup_server: ServerInstance) -> Iterator[str]:
     """A running nginx-webdav server for testing
 
     It's nice to have a module-scoped fixture for the server, so we can
@@ -411,8 +438,25 @@ def nginx_server(setup_server) -> Iterator[str]:
     """
 
     pre_time = datetime.datetime.now().isoformat()
-    yield f"http://localhost:{setup_server['port']}/webdav"
+    yield setup_server.hosturl
 
     subprocess.check_call(
-        ["podman", "logs", "--since", pre_time, setup_server["container_id"]]
+        ["podman", "logs", "--since", pre_time, setup_server.container_id]
     )
+
+
+@pytest.fixture()
+def nginx_cluster(setup_cluster: list[ServerInstance]):
+    """A running nginx-webdav cluster for testing
+
+    It's nice to have a module-scoped fixture for the server, so we can
+    reduce the number of irrelevant log messages in the test output.
+    """
+
+    pre_time = datetime.datetime.now().isoformat()
+    yield setup_cluster
+
+    for server in setup_cluster:
+        subprocess.check_call(
+            ["podman", "logs", "--since", pre_time, server.container_id]
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -276,6 +276,8 @@ def setup_server(build_container: None, oidc_mock_idp: MockIdP) -> Iterator[dict
         "./nginx/lua/config.json:/etc/nginx/lua/config.json:ro",
         "--tmpfs",
         "/var/www/webdav:rw,size=100M,mode=1777",
+        "-e",
+        "DEBUG=true",
         # Set the name of the container so it will fail early if the old
         # container wasn't cleaned up
         "--name",
@@ -372,6 +374,8 @@ def setup_cluster(build_container: None, oidc_mock_idp: MockIdP):
             f"SERVER_NAME=nginx-webdav-test{i}",
             "-e",
             f"PORT={8580 + i}",
+            "-e",
+            "DEBUG=true",
             "--name",
             f"nginx-webdav-test{i}",
         ]

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -69,6 +69,7 @@ def test_cluster_redirect(setup_cluster, wlcg_create_header, wlcg_read_header):
 
     for j, server in enumerate(setup_cluster):
         for i in range(len(setup_cluster)):
+            # we can't follow the redirect because the server name is only known inside the podman network
             response = httpx.get(
                 f"{server}redirect/unique_file{i}.txt", headers=wlcg_read_header
             )

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -12,7 +12,7 @@ def test_cluster_gossip(setup_cluster, hepcdn_access_header):
     data = {}
     for _ in range(30):
         for server in setup_cluster:
-            response = httpx.get(f"{server}/gossip", headers=hepcdn_access_header)
+            response = httpx.get(f"{server}gossip", headers=hepcdn_access_header)
             data[server] = response.json()
 
         if all(len(item) == len(setup_cluster) for item in data.values()):
@@ -27,7 +27,12 @@ def test_cluster_gossip(setup_cluster, hepcdn_access_header):
         for item in items:
             assert item.keys() == {"name", "data"}
             assert item["data"]["status"] == "alive"
-            assert set(item["data"].keys()) == {"status", "epoch", "timestamp", "server_version"}
+            assert set(item["data"].keys()) == {
+                "status",
+                "epoch",
+                "timestamp",
+                "server_version",
+            }
 
 
 def test_cluster_tpc(setup_cluster, wlcg_create_header):
@@ -51,3 +56,27 @@ def test_cluster_tpc(setup_cluster, wlcg_create_header):
     response = httpx.request("COPY", dst, headers=headers)
     assert response.status_code == httpx.codes.ACCEPTED
     assert response.text.strip() == "success: Created"
+
+
+def test_cluster_redirect(setup_cluster, wlcg_create_header, wlcg_read_header):
+    for i, server in enumerate(setup_cluster):
+        path = f"{server}webdav/unique_file{i}.txt"
+        data = "Hello, world!" * 10_000
+
+        response = httpx.put(path, headers=wlcg_create_header, content=data)
+        assert_status(response, httpx.codes.CREATED)
+        assert response.text == "file created\n"
+
+    for j, server in enumerate(setup_cluster):
+        for i in range(len(setup_cluster)):
+            response = httpx.get(
+                f"{server}redirect/unique_file{i}.txt", headers=wlcg_read_header
+            )
+            assert_status(response, httpx.codes.TEMPORARY_REDIRECT)
+            if i == j:
+                assert response.headers["Location"] == f"/webdav/unique_file{i}.txt"
+            else:
+                assert (
+                    response.headers["Location"]
+                    == f"http://nginx-webdav-test{i}:858{i}/webdav/unique_file{i}.txt"
+                )


### PR DESCRIPTION
Towards #9 

This adds a `/redirect/...` endpoint that first queries if the local path exists, and if not it queries all peers in the current gossip peer list and returns a redirect to the first peer that replies