### PR TITLE
Handle lost peers (WIP)

### DIFF
--- a/nginx/docker-entrypoint.sh
+++ b/nginx/docker-entrypoint.sh
@@ -46,7 +46,7 @@ fi
 
 if [ "$DEBUG" == "true" ]; then
   cat <<EOF >> /etc/nginx/conf.d/site.conf
-error_log stderr notice;
+error_log stderr info;
 
 server {
     lua_code_cache off;

--- a/nginx/lua/config.lua
+++ b/nginx/lua/config.lua
@@ -20,6 +20,7 @@ local Config = {
         gossip_fraction = 0.1, -- fraction of peers to gossip to
         gossip_max_failures = 5, -- max failures before removing a peer
         gossip_timeout = 5000, -- in milliseconds
+        peer_query_timeout = 5000, -- in milliseconds
 
         -- This is used in webdav_write_content and webdav_tpc_content
         receive_buffer_size = 1024*1024,

--- a/nginx/lua/config.lua
+++ b/nginx/lua/config.lua
@@ -18,6 +18,7 @@ local Config = {
         seed_peers = "", -- comma separated list of seed peers
         gossip_delay = 10, -- in seconds
         gossip_fraction = 0.1, -- fraction of peers to gossip to
+        gossip_max_failures = 5, -- max failures before removing a peer
 
         -- This is used in webdav_write_content and webdav_tpc_content
         receive_buffer_size = 1024*1024,

--- a/nginx/lua/config.lua
+++ b/nginx/lua/config.lua
@@ -19,6 +19,7 @@ local Config = {
         gossip_delay = 10, -- in seconds
         gossip_fraction = 0.1, -- fraction of peers to gossip to
         gossip_max_failures = 5, -- max failures before removing a peer
+        gossip_timeout = 5000, -- in milliseconds
 
         -- This is used in webdav_write_content and webdav_tpc_content
         receive_buffer_size = 1024*1024,

--- a/nginx/lua/gossip.lua
+++ b/nginx/lua/gossip.lua
@@ -55,7 +55,7 @@ function Gossip.remove_peer(peer)
     ---@cast peerstr string
     local pos, endpos = peerstr:find(peer, 1, true)
     if not pos then
-        ngx.log(ngx.WARN, "Peer " .. peer .. " not found in peerstr: " .. peerstr)
+        ngx.log(ngx.WARN, "Logic error: peer " .. peer .. " not found in peerstr: " .. peerstr)
         return
     end
     -- Account for trailing comma

--- a/nginx/lua/gossip.lua
+++ b/nginx/lua/gossip.lua
@@ -49,6 +49,8 @@ end
 ---@param peer string
 ---Remove a peer from the list of peers
 function Gossip.remove_peer(peer)
+    -- Flush any timestamp
+    ngx.shared.gossip_data:set("timestamp:" .. peer, nil)
     local peerstr = ngx.shared.gossip_data:get("peers")
     ---@cast peerstr string
     local pos, endpos = peerstr:find(peer, 1, true)

--- a/nginx/lua/gossip.lua
+++ b/nginx/lua/gossip.lua
@@ -110,7 +110,7 @@ function Gossip.update_peerdata(peer, peerdata)
             ngx.log(ngx.WARN, "Not adding new peer " .. peer .. " because it has failed " .. peerdata.failures .. " times")
             return
         end
-        ngx.log(ngx.WARN, "Adding new peer " .. peer)
+        ngx.log(ngx.NOTICE, "Adding new peer " .. peer)
         -- Set its data first to reduce race conditions?
         Gossip.set_peerdata(peer, peerdata)
         -- Potential TODO: factor this out to a once-per-gossip update
@@ -179,7 +179,7 @@ function Gossip.handle_peer_error(peer, err)
     ngx.shared.gossip_data:set("timestamp:" .. peer, ngx.now())
     ngx.shared.gossip_data:set("status:" .. peer, "failed: " .. err)
     if failures and failures >= config.data.gossip_max_failures then
-        ngx.log(ngx.WARN, "Peer " .. peer .. " failed " .. failures .. " times, removing from list")
+        ngx.log(ngx.NOTICE, "Peer " .. peer .. " failed " .. failures .. " times, removing from list")
         Gossip.remove_peer(peer)
     end
 end

--- a/nginx/lua/gossip_content.lua
+++ b/nginx/lua/gossip_content.lua
@@ -1,6 +1,7 @@
 local gossip = require("gossip")
 
--- Handle posted message
+-- If the request method is a POST, then it is a peer
+-- contacting us with its gossip update and we need to handle it
 if ngx.var.request_method == "POST" then
     ngx.req.read_body()
     local data = ngx.req.get_body_data()

--- a/nginx/lua/init_worker.lua
+++ b/nginx/lua/init_worker.lua
@@ -25,6 +25,9 @@ local token_userpass = config.data.openidc_client_id .. ":" .. config.data.openi
 ---@param token string
 local function peer_exchange_gossip(peer, message, token)
     local httpc = resty_http.new()
+    -- timeouts (connect, send, read) are in milliseconds
+    httpc:set_timeouts(config.data.gossip_timeout, config.data.gossip_timeout, config.data.gossip_timeout)
+    ngx.log(ngx.INFO, "Sending gossip message to ", peer)
     local res, err = httpc:request_uri(peer .. "gossip", {
         method = "POST",
         body = message,

--- a/nginx/lua/redirect_content.lua
+++ b/nginx/lua/redirect_content.lua
@@ -23,6 +23,7 @@ end
 ---@return {peer: string, location: string?} res Response from peer
 local function peer_query_file(peer, uri, token)
     local httpc = resty_http.new()
+    httpc:set_timeouts(config.data.peer_query_timeout, config.data.peer_query_timeout, config.data.peer_query_timeout)
     -- peer has trailing slash, uri has leading slash
     local location = peer .. uri:sub(2)
     ngx.log(ngx.NOTICE, "Querying location: ", location)
@@ -35,7 +36,7 @@ local function peer_query_file(peer, uri, token)
     })
     if not res then
         ngx.log(ngx.ERR, "Failed to send file query to " .. peer .. ": " .. err)
-        -- TODO: update peer status for gossip (unreachable)
+        gossip.handle_peer_error(peer, err)
         return {peer = peer, location = nil}
     end
     if res.status == ngx.HTTP_OK then

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -362,6 +362,8 @@ def setup_cluster(build_container: None, oidc_mock_idp: MockIdP):
             "openidc_iss": oidc_mock_idp.iss,
             "openidc_pubkey": oidc_mock_idp.public_key_pem,
             "gossip_delay": 1,
+            "gossip_fraction": 0.5,
+            "gossip_max_failures": 1,
             "openidc_client_id": f"nginx{i}",
             "openidc_client_secret": f"nginx{i}_secret",
             "health_check_id": random.randint(0, 1024 * 1024 * 1024),
@@ -402,6 +404,7 @@ def setup_cluster(build_container: None, oidc_mock_idp: MockIdP):
         container_id = subprocess.check_output(podman_cmd).decode().strip()
         container_ids.append(container_id)
 
+    time.sleep(1)
     yield [
         ServerInstance(
             port=8580 + i,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -364,6 +364,7 @@ def setup_cluster(build_container: None, oidc_mock_idp: MockIdP):
             "gossip_delay": 1,
             "gossip_fraction": 0.5,
             "gossip_max_failures": 1,
+            "gossip_timeout": 100,
             "openidc_client_id": f"nginx{i}",
             "openidc_client_secret": f"nginx{i}_secret",
             "health_check_id": random.randint(0, 1024 * 1024 * 1024),


### PR DESCRIPTION
Handle lost peers in our federation. After 5 failures (connect/read/etc.) we drop the peer from the list. It can rejoin if it manages to spread its own gossip message with the failures reset to 0.