### PR TITLE
Move set oidc_user to server block

### DIFF
--- a/nginx/conf.d/include/locations.conf
+++ b/nginx/conf.d/include/locations.conf
@@ -1,10 +1,8 @@
 # This is meant to be included by the site.conf
 # the $upstream_location map is defined in default.conf
 
-location * {
-    # Set oidc_user for later use in the log format
-    set $oidc_user '';
-}
+# Set oidc_user for later use in the log format
+set $oidc_user '';
 
 location / {
     return 404;


### PR DESCRIPTION
Hopefully suppresses warnings like
```
2025/04/23 22:05:40 [warn] 12#0: *340 using uninitialized "oidc_user" variable while logging request, client: 10.76.82.2, server: cms-hepcdn.web.cern.ch, request: "GET /webdav HTTP/1.1", host: "cms-hepcdn.web.cern.ch"
```